### PR TITLE
✨ & ✏️ Feat, Chore: [2024-01-01 | smiledk] BOJ(dp) - S2193, S1912, S10844, S9461 & S11659

### DIFF
--- a/src/algorithm/solution/smileDK/baejoon/dp/S10844.java
+++ b/src/algorithm/solution/smileDK/baejoon/dp/S10844.java
@@ -1,0 +1,45 @@
+package algorithm.solution.smileDK.baejoon.dp;
+
+import algorithm.problem.baekjoon.dp.P10844;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class S10844 implements P10844 {
+
+    private final static long mod = 1000000000;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        long[][] dp = new long[n+1][10];
+
+        for (int i = 1; i < 10; i++) {
+            dp[1][i] = 1;
+        }
+
+        for (int i = 2; i <= n; i++) {
+            for (int j = 0; j < 10; j++) {
+                if (j == 0) {
+                    dp[i][0] = dp[i - 1][1] % mod;
+                }
+                else if (j == 9) {
+                    dp[i][9] = dp[i - 1][9] % mod;
+                }
+                else {
+                    dp[i][j] = (dp[i - 1][j - 1] + dp[i - 1][j + 1]) % mod;
+                }
+            }
+        }
+
+        long temp = 0;
+
+        for (int i = 0; i < 10; i++) {
+            temp += dp[n][i];
+        }
+
+        System.out.println(temp % mod);
+    }
+}

--- a/src/algorithm/solution/smileDK/baejoon/dp/S1149.java
+++ b/src/algorithm/solution/smileDK/baejoon/dp/S1149.java
@@ -22,7 +22,6 @@ import java.util.StringTokenizer;
     d[i][0] = i번째 집까지 칠할 때 비용의 최솟값, 단 i번째 집은 빨강
     d[i][1] = i번째 집까지 칠할 때 비용의 최솟값, 단 i번째 집은 초록
     d[i][2] = i번째 집까지 칠할 때 비용의 최솟값, 단 i번째 집은 파랑
-    * Recurrence
     d[k][0] = min(d[k-1][1], d[k-1][2]) + R[k]
     d[k][1] = min(d[k-1][0], d[k-1][2]) + G[k]
     d[k][2] = min(d[k-1][0], d[k-1][1]) + B[k]

--- a/src/algorithm/solution/smileDK/baejoon/dp/S11659.java
+++ b/src/algorithm/solution/smileDK/baejoon/dp/S11659.java
@@ -1,0 +1,42 @@
+package algorithm.solution.smileDK.baejoon.dp;
+
+import algorithm.problem.baekjoon.dp.P11659;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class S11659 implements P11659 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[] d = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            d[i] = Integer.parseInt(st.nextToken());
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        while (m-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            int i = Integer.parseInt(st.nextToken());
+            int j = Integer.parseInt(st.nextToken());
+
+            int sum = 0;
+
+            for(int k = i-1; k < j; k++) {
+                sum += d[k];
+            }
+            sb.append(sum).append('\n');
+        }
+
+        System.out.println(sb);
+
+    }
+}

--- a/src/algorithm/solution/smileDK/baejoon/dp/S1912.java
+++ b/src/algorithm/solution/smileDK/baejoon/dp/S1912.java
@@ -1,0 +1,36 @@
+package algorithm.solution.smileDK.baejoon.dp;
+
+import algorithm.problem.baekjoon.dp.P1912;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class S1912 implements P1912 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] sequence = new int[n];
+        int[] dp = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            sequence[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp[0] = sequence[0];
+        int max = sequence[0];
+
+        for (int i = 1; i < n; i++) {
+            // (이전 dp + 현재 arr값) 과 현재 arr값 중 큰 것을 dp에 저장
+            dp[i] = Math.max(dp[i - 1] + sequence[i], sequence[i]);
+            // 최댓값 갱신
+            max = Math.max(max, dp[i]);
+        }
+        System.out.println(max);
+    }
+}

--- a/src/algorithm/solution/smileDK/baejoon/dp/S2193.java
+++ b/src/algorithm/solution/smileDK/baejoon/dp/S2193.java
@@ -1,0 +1,48 @@
+package algorithm.solution.smileDK.baejoon.dp;
+
+import algorithm.problem.baekjoon.dp.P2193;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/*Todo
+    이친수 Rule
+    1. 0으로 시작 x
+    2. 1 두 번 연속 x
+    * Table Definition
+    D[i] = i자리 이친수 개수
+    * Recurrence
+    D[1] = 1 -> 1
+    D[2] = 10 -> 1
+    D[3] = 100, 101 -> 2 => D[1] + 1
+    D[4] = 1000, 1001, 1010 -> 3 => D[1] + D[2] + 1
+    D[5] = 10000, 10001, 10010, 10100, 10101 -> 5 => D[1] + D[2] + D[3] + 1
+    D[6] = 100000, 100001, 100010, 100100, 100101, 101000, 101001, 101010 -> 8 => D[1] + D[2] + D[3] + D[4] + 1
+    D[i] = D[1] + D[2] + ... + D[i-2] + 1
+    * 오답 노트
+    배열의 크기를 할당할 때 n+1로 하면 dp[2]일 때 OutOfRange를 만날 수 있다.
+    따라서, 배열의 크기를 문제의 입력 크기 만큼 할당하거나, 배열의 크기를 벗어난 요소가 있는 지 확인해야 한다.
+* */
+
+
+public class S2193 implements P2193 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        long[] dp = new long[n + 2];
+
+        dp[1] = 1;
+        dp[2] = 1;
+
+        for (int i = 3; i <= n; i++) {
+            for(int j = 1; j <= i - 2; j++) {
+                dp[i] += dp[j];
+            }
+            dp[i] += 1;
+        }
+
+        System.out.println(dp[n]);
+    }
+}

--- a/src/algorithm/solution/smileDK/baejoon/dp/S9461.java
+++ b/src/algorithm/solution/smileDK/baejoon/dp/S9461.java
@@ -1,0 +1,35 @@
+package algorithm.solution.smileDK.baejoon.dp;
+
+import algorithm.problem.baekjoon.dp.P9461;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class S9461 implements P9461 {
+    private static final Long[] sequence = new Long[101];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        sequence[0] = 0L;
+        sequence[1] = 1L;
+        sequence[2] = 1L;
+        sequence[3] = 1L;
+
+        int t = Integer.parseInt(br.readLine());
+
+        while(t-- > 0) {
+            sb.append(padovan(Integer.parseInt(br.readLine()))).append('\n');
+        }
+        System.out.println(sb);
+    }
+
+    public static long padovan(int n) {
+        if(sequence[n] == null) {
+            sequence[n] = padovan(n - 2) + padovan(n - 3);
+        }
+        return sequence[n];
+    }
+}


### PR DESCRIPTION
TimeOut

Reviewed-by:
합을 계산할 때 매번 반복문을 통해 배열을 순회한 후 합을 구하고 있기때문에 시간초과가 난 게 아닌 가 생각해본다. 
테스트 케이스가 많을 수록 중복 계산이 발생하므로 추후 다시 도전할 때 입력 배열의 누적 합을 미리 계산하고 누적합 배열을 사용하여 필요한 구간 합을 계산하는 방식으로 구현해봐야겠다.

Retry!!